### PR TITLE
Allow space in program name

### DIFF
--- a/src/kwin-autosuspend.sh
+++ b/src/kwin-autosuspend.sh
@@ -8,7 +8,7 @@
 
 blacklist="firefox"
 blacklist_path=~/.config/kwin-autosuspend/blacklist.txt
-[[ -f "$blacklist_path" ]] && blacklist="$blacklist $(cat $blacklist_path)"
+[[ -f "$blacklist_path" ]] && blacklist="$blacklist,$(cat $blacklist_path)"
 
 function handle_exit() {
     turn_effects_on
@@ -72,14 +72,17 @@ xprop -spy -root _NET_ACTIVE_WINDOW | grep --line-buffered -o '0[xX][a-zA-Z0-9]\
 while read -r id; do
     check_kwin
     [[ -n "$last_id" ]] && [[ "$last_id" == "$id" ]] && continue
-    program_name="$(xprop -id "$id" WM_CLASS | awk '{print tolower($4)}')"
+    program_name="$(xprop -id "$id" WM_CLASS | cut -d '"' -f2)"
     skip=0
+    old_ifs=$IFS
+    export IFS=","
     for name in $blacklist; do
-        if [[ \"$name\" = $program_name ]]; then
+        if [[ $name = $program_name ]]; then
             skip=1
             break
         fi
     done
+    export IFS=$old_ifs
     [[ $skip -eq 0 ]] && run_checks_on_window "$id" &
     last_id=$id
 done


### PR DESCRIPTION
This might break the blacklist file, as the program names need to be comma-separated inside of the blacklist.txt